### PR TITLE
add benchmark tests

### DIFF
--- a/statsd_benchmark_test.go
+++ b/statsd_benchmark_test.go
@@ -10,27 +10,29 @@ import (
 var result error
 var strResult string
 
-func benchFakeClient(buffer *bytes.Buffer) *Client {
+func benchFakeClient() *Client {
+	buf := new(bytes.Buffer)
 	return &Client{
-		buf: bufio.NewWriterSize(buffer, defaultBufSize),
+		buf: bufio.NewWriterSize(buf, defaultBufSize),
 	}
 }
 
 func BenchmarkIncrement(b *testing.B) {
 	var r error
-	buf := new(bytes.Buffer)
-	c := benchFakeClient(buf)
+	c := benchFakeClient()
 
 	for i := 0; i < b.N; i++ {
 		r = c.Increment("incr", 1, 1)
 	}
+	// we are assigning r to results in these tests to prevent the compiler
+	// from optimizing out the test alltogether (bottom of article)
+	// http://dave.cheney.net/2013/06/30/how-to-write-benchmarks-in-go
 	result = r
 }
 
 func BenchmarkDecrement(b *testing.B) {
 	var r error
-	buf := new(bytes.Buffer)
-	c := benchFakeClient(buf)
+	c := benchFakeClient()
 
 	for i := 0; i < b.N; i++ {
 		r = c.Decrement("decr", 1, 1)
@@ -40,8 +42,7 @@ func BenchmarkDecrement(b *testing.B) {
 
 func BenchmarkDuration(b *testing.B) {
 	var r error
-	buf := new(bytes.Buffer)
-	c := benchFakeClient(buf)
+	c := benchFakeClient()
 	time := time.Duration(123456789)
 
 	for i := 0; i < b.N; i++ {
@@ -52,8 +53,7 @@ func BenchmarkDuration(b *testing.B) {
 
 func BenchmarkGauge(b *testing.B) {
 	var r error
-	buf := new(bytes.Buffer)
-	c := benchFakeClient(buf)
+	c := benchFakeClient()
 
 	for i := 0; i < b.N; i++ {
 		r = c.Gauge("gauge", 300, 1)
@@ -63,8 +63,7 @@ func BenchmarkGauge(b *testing.B) {
 
 func BenchmarkIncrementGauge(b *testing.B) {
 	var r error
-	buf := new(bytes.Buffer)
-	c := benchFakeClient(buf)
+	c := benchFakeClient()
 
 	for i := 0; i < b.N; i++ {
 		r = c.IncrementGauge("gauge", 10, 1)
@@ -74,8 +73,7 @@ func BenchmarkIncrementGauge(b *testing.B) {
 
 func BenchmarkDecrementGauge(b *testing.B) {
 	var r error
-	buf := new(bytes.Buffer)
-	c := benchFakeClient(buf)
+	c := benchFakeClient()
 
 	for i := 0; i < b.N; i++ {
 		r = c.DecrementGauge("gauge", 4, 1)
@@ -85,8 +83,7 @@ func BenchmarkDecrementGauge(b *testing.B) {
 
 func BenchmarkUnique(b *testing.B) {
 	var r error
-	buf := new(bytes.Buffer)
-	c := benchFakeClient(buf)
+	c := benchFakeClient()
 
 	for i := 0; i < b.N; i++ {
 		r = c.Unique("unique", 765, 1)
@@ -96,8 +93,7 @@ func BenchmarkUnique(b *testing.B) {
 
 func BenchmarkTiming(b *testing.B) {
 	var r error
-	buf := new(bytes.Buffer)
-	c := benchFakeClient(buf)
+	c := benchFakeClient()
 
 	for i := 0; i < b.N; i++ {
 		r = c.Timing("timing", 350, 1)
@@ -107,8 +103,7 @@ func BenchmarkTiming(b *testing.B) {
 
 func BenchmarkTime(b *testing.B) {
 	var r error
-	buf := new(bytes.Buffer)
-	c := benchFakeClient(buf)
+	c := benchFakeClient()
 
 	for i := 0; i < b.N; i++ {
 		r = c.Time("time", 1, func() {})


### PR DESCRIPTION
This is just getting a start on having a set of benchmark tests. Driven out of a discussion on https://github.com/sendgrid/go-statsdclient/pull/2 (I will follow up on that pr with comparisons)

Initial results are

```
BenchmarkIncrement   1000000          1243 ns/op
BenchmarkDecrement   1000000          1242 ns/op
BenchmarkDuration    1000000          1896 ns/op
BenchmarkGauge   1000000          1228 ns/op
BenchmarkIncrementGauge  1000000          1219 ns/op
BenchmarkDecrementGauge  1000000          1210 ns/op
BenchmarkUnique  1000000          1293 ns/op
BenchmarkTiming  1000000          1214 ns/op
BenchmarkTime    1000000          2104 ns/op
BenchmarkPrefix  5000000           440 ns/op 
```
