### PR TITLE
COE-50 add size configurable mock client

### DIFF
--- a/.jenkins
+++ b/.jenkins
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+PKG="github.com/sendgrid/go-statsdclient"
+
+set -ex
+
+docker run \
+    --volume="$PWD:/opt/go/src/$PKG" \
+    --env="GOPATH=/opt/go/" \
+    --workdir=/opt/go/src/$PKG \
+    docker.sendgrid.net/sendgrid/dev_go-1.4 go vet ./...
+
+docker run \
+    --volume="$PWD:/opt/go/src/$PKG" \
+    --env="GOPATH=/opt/go/" \
+    --workdir=/opt/go/src/$PKG \
+    docker.sendgrid.net/sendgrid/dev_go-1.4 go get github.com/bmizerany/assert && go test -race -timeout=1m ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog
 =========
+# 3.2.0
+- Add buffer-size configurable mock client
+
 # 3.1.0
 - Exposing the Unique statsd method
 

--- a/mock.go
+++ b/mock.go
@@ -53,3 +53,12 @@ func NewMockClient() *MockClient {
 		buffer: buffer,
 	}
 }
+
+// Create a mock of the StatsClient with a configurable buffer size
+func NewMockClientSize(size int) *MockClient {
+	buffer := new(bytes.Buffer)
+	return &MockClient{
+		client: client{buf: bufio.NewWriterSize(buffer, size)},
+		buffer: buffer,
+	}
+}

--- a/statsdclienttest/stats_client.go
+++ b/statsdclienttest/stats_client.go
@@ -125,7 +125,7 @@ func (m *StatsClient) AssertLoggedN(t Testable, stat StatsCommand, n int) {
 	defer m.mutex.RUnlock()
 
 	if m.commands[stat] != n {
-		t.Errorf("stat %q logged %d times, expected %d times", stat, m.commands[stat], n)
+		t.Errorf("stat %+v logged %d times, expected %d times", stat, m.commands[stat], n)
 	}
 }
 

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package statsdclient
 
-const VERSION = "3.1.0"
+const VERSION = "3.2.0"


### PR DESCRIPTION
# Summary
 Adding a constructor for a buffer-size configurable mock client because if the default size is exceeded, a flush results in 

## PR - Merge Checklist:
- [ ] CR'd
- [x] Version updated (version #3.2.0)
- [x] CHANGELOG updated
- [x] README updated or N/A
- [ ] [Jenkins build passes](link the passing build here)
- [x] Dependencies satisfied {db-schema,upstream repos,chef,config,hardware,ops - Add bullet points with links to corresponding PRs/tickets}

## Dependencies:
- [x] n/a