### PR TITLE
CES-233 utility to create statsd prefix from env, app name & host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog
 =========
+# 3.2.1
+- Utility to create statsd prefix in form environment.appname.hostname
+
 # 3.2.0
 - Add buffer-size configurable mock client
 

--- a/statsd.go
+++ b/statsd.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -100,6 +101,20 @@ func (c *client) SetPrefix(prefix string) {
 	c.m.Lock()
 	defer c.m.Unlock()
 	c.prefix = strings.TrimRight(prefix, ".") + "."
+}
+
+// makeStatsPrefix will create a stats key prefix based on the given environment, application name, and hostname.
+func MakeStatsdPrefix(namespace, app, hostname string) string {
+	underscoreHostname := strings.Replace(hostname, ".", "_", -1)
+	return fmt.Sprintf("%s.%s.%s.", namespace, app, underscoreHostname)
+}
+
+var GetHostname = func() (string, error) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "UNKNOWN"
+	}
+	return hostname, err
 }
 
 // Increment the counter for the given bucket.

--- a/statsd.go
+++ b/statsd.go
@@ -109,7 +109,7 @@ func MakeStatsdPrefix(namespace, app, hostname string) string {
 	return fmt.Sprintf("%s.%s.%s.", namespace, app, underscoreHostname)
 }
 
-var GetHostname = func() (string, error) {
+func GetHostname() (string, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
 		hostname = "UNKNOWN"

--- a/statsd_test.go
+++ b/statsd_test.go
@@ -1,9 +1,11 @@
 package statsdclient
 
 import (
-	"github.com/bmizerany/assert"
+	"fmt"
 	"testing"
 	"time"
+
+	"github.com/bmizerany/assert"
 )
 
 func TestIncrement(t *testing.T) {
@@ -198,4 +200,14 @@ func TestMultipleCloses(t *testing.T) {
 	assert.NotEqual(t, nil, "This should be an error on subsequent closes")
 	err = c.Close()
 	assert.NotEqual(t, nil, "This should be an error on subsequent closes")
+}
+
+func TestMakeStatsdPrefix(t *testing.T) {
+	nameSpace := "testing"
+	app := "testApp"
+	hostName := "center.for.kids.who.cant.read.good"
+	expectedPrefix := fmt.Sprintf("%s.%s.center_for_kids_who_cant_read_good.", nameSpace, app)
+
+	actualPrefix := MakeStatsdPrefix(nameSpace, app, hostName)
+	assert.Equal(t, expectedPrefix, actualPrefix)
 }

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package statsdclient
 
-const VERSION = "3.2.0"
+const VERSION = "3.2.1"


### PR DESCRIPTION
# Summary
  Add functions to create a statsd namespace in the form environment.appname.hostname

## PR - Merge Checklist:
- [x] CR'd
- [x] Version updated (version #3.2.1)
- [x] CHANGELOG updated
- [x] README updated or N/A
- [ ] [Jenkins build passes](link the passing build here)
- [x] Dependencies satisfied {db-schema,upstream repos,chef,config,hardware,ops - Add bullet points with links to corresponding PRs/tickets}
- [x] Acceptance criteria verified by QE
- [x] Fully tested and approved by QE

## Dependencies:
- [x] n/a

## Risks:
These are new functions that are not currently used anywhere
## Rollback:
Revert