### PR TITLE
Expose client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog
 =========
+# 3.3.0
+- Expose the Client and have Dial return it instead of the StatsClient
+
 # 3.2.2
 - Patch change to ensure that udp continues to send even if downstream server is not available
  

--- a/mock.go
+++ b/mock.go
@@ -8,7 +8,7 @@ import (
 )
 
 type MockClient struct {
-	client
+	Client
 	buffer *bytes.Buffer
 }
 
@@ -54,7 +54,7 @@ func NewMockClient() *MockClient {
 func NewMockClientSize(size int) *MockClient {
 	buffer := new(bytes.Buffer)
 	return &MockClient{
-		client: client{buf: bufio.NewWriterSize(buffer, size)},
+		Client: Client{buf: bufio.NewWriterSize(buffer, size)},
 		buffer: buffer,
 	}
 }

--- a/statsd_test.go
+++ b/statsd_test.go
@@ -229,15 +229,9 @@ func TestUDPServerCloses(t *testing.T) {
 	}()
 
 	// Dial to whatever UDP server was created
-	conn, err := Dial(listener.LocalAddr().String())
+	client, err := Dial(listener.LocalAddr().String())
 	if err != nil {
 		t.Fatal(err)
-	}
-
-	// We need the client for the flush method - the StatsClient interface does not expose it
-	client, ok := conn.(*client)
-	if !ok {
-		t.Fatal("do not have a client - it is needed to manually trigger a flush")
 	}
 
 	err = client.Gauge(strings.Repeat("k.", 256), 1, 1)

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package statsdclient
 
-const VERSION = "3.2.2"
+const VERSION = "3.3.0"


### PR DESCRIPTION
Expose `Client` so that we have access to other metrics functions (IncrementGauge, etc...) but without breaking the interface.